### PR TITLE
Upgrade to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 MAINTAINER alex.devalx@gmail.com
 


### PR DESCRIPTION
Use Ubuntu 16.04 LTS, since 15.10 isn't supported anymore (since July 28th, 2016)