### PR TITLE
Update Ts3 Version (minior), set encoding to UTF-8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV LC_ALL en_US.UTF-8
 
 USER ts3
 ENTRYPOINT ["/home/ts3/teamspeak3-server_linux_amd64/ts3server_minimal_runscript.sh"]
-CMD ["inifile=/home/ts3/data/ts3server.ini", "logpath=/home/ts3/data/logs","licensepath=/home/ts3/data/","query_ip_whitelist=/home/ts3/data/query_ip_whitelist.txt","query_ip_backlist=/home/ts3/data/query_ip_blacklist.txt"]
+CMD ["inifile=/home/ts3/data/ts3server.ini", "logpath=/home/ts3/data/logs","licensepath=/home/ts3/data/","query_ip_whitelist=/home/ts3/data/query_ip_whitelist.txt","query_ip_backlist=/home/ts3/data/query_ip_blacklist.txt", "license_accepted=1"]
 
 VOLUME ["/home/ts3/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_VERSION 3.5.1
+ENV TEAMSPEAK_VERSION 3.7.1
 ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
-ENV TEAMSPEAK_SHA256 aa991a7b88f4d6e24867a98548b808c093771b85443f986c8adb09e78e41eb79
+ENV TEAMSPEAK_SHA256 6787d4c9fd6f72d1386872a61f38f932a8ee745046b1497168286ffd0311c0f0
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_VERSION 3.7.1
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
-ENV TEAMSPEAK_SHA256 6787d4c9fd6f72d1386872a61f38f932a8ee745046b1497168286ffd0311c0f0
+ENV TEAMSPEAK_VERSION 3.9.1
+ENV TEAMSPEAK_URL https://files.teamspeak-services.com/releases/server/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
+ENV TEAMSPEAK_SHA256 0a0497d6a8e5f3f48e10db8f89875286d6aa3388f171f828cf5d426cf305f16f
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.3.1/teamspeak3-server_linux_amd64-3.5.1.tar.bz2
+ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.5.1/teamspeak3-server_linux_amd64-3.5.1.tar.bz2
 ENV TEAMSPEAK_SHA256 aa991a7b88f4d6e24867a98548b808c093771b85443f986c8adb09e78e41eb79
 ENV TS3_UID 1000
 
@@ -11,7 +11,7 @@ RUN apt-get update -q \
   && rm -rf /var/lib/apt \
   && useradd -u ${TS3_UID} ts3 \
   && mkdir -p /home/ts3 \
-  && wget -q -O /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 ${TEAMSPEAK_URL} \
+  && wget -O /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 ${TEAMSPEAK_URL} \
   && test ${TEAMSPEAK_SHA256} =  $(sha256sum /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 |awk '{print $1}')\
   && tar --directory /home/ts3 -xjf /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 \
   && rm /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -q \
   && ln -s /home/ts3/data/ts3server.sqlitedb /home/ts3/teamspeak3-server_linux_amd64/ts3server.sqlitedb \
   && chown -R ts3 /home/ts3 \
   && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+  && touch /home/ts3/.ts3server_license_accepted \
   && locale-gen
 # Symlink because i dont know how to move sqlite-db (like dbpath=/data/ts/mysqlite.db)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:16.04
 
 ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
+# For the sake of safty, update and validate this hash for each new release!
+ENV TEAMSPEAK_SHA256 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
 ENV TS3_UID 1000
 
 RUN apt-get update -q \
@@ -10,6 +12,7 @@ RUN apt-get update -q \
   && useradd -u ${TS3_UID} ts3 \
   && mkdir -p /home/ts3 \
   && wget -q -O /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 ${TEAMSPEAK_URL} \
+  && test ${TEAMSPEAK_SHA256} =  $(sha256sum /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 |awk '{print $1}')\
   && tar --directory /home/ts3 -xjf /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 \
   && rm /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 \
   && mkdir -p /home/ts3/data/logs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.3.1/teamspeak3-server_linux_amd64-3.3.1.tar.bz2
-ENV TEAMSPEAK_SHA256 b3891341a9ff4c4b6b0173ac57f1d64d4752550c95eeb26d2518ac2f5ca9fbc1
+ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.3.1/teamspeak3-server_linux_amd64-3.5.1.tar.bz2
+ENV TEAMSPEAK_SHA256 aa991a7b88f4d6e24867a98548b808c093771b85443f986c8adb09e78e41eb79
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
+ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.1.1/teamspeak3-server_linux_amd64-3.1.1.tar.bz2
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_SHA256 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
+ENV TEAMSPEAK_SHA256 c9403f7958e1bf1c5e5cf083641b1e02b06800158df543e09d9259c69181e873
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_VERSION 3.9.1
+ENV TEAMSPEAK_VERSION 3.10.0
 ENV TEAMSPEAK_URL https://files.teamspeak-services.com/releases/server/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
-ENV TEAMSPEAK_SHA256 0a0497d6a8e5f3f48e10db8f89875286d6aa3388f171f828cf5d426cf305f16f
+ENV TEAMSPEAK_SHA256 5d0ade1cc3802cae75cf2b1d22b14163154a0d1d77d5aded7e56c826d023d6dd
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_VERSION 3.10.0
+ENV TEAMSPEAK_VERSION 3.10.2
 ENV TEAMSPEAK_URL https://files.teamspeak-services.com/releases/server/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
-ENV TEAMSPEAK_SHA256 5d0ade1cc3802cae75cf2b1d22b14163154a0d1d77d5aded7e56c826d023d6dd
+ENV TEAMSPEAK_SHA256 d4262f0d51e682c0c645b36c196ad32dae99a1345420cfad00d52f2af109870d
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.1.1/teamspeak3-server_linux_amd64-3.1.1.tar.bz2
+ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.1.1/teamspeak3-server_linux_amd64-3.3.1.tar.bz2
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_SHA256 c9403f7958e1bf1c5e5cf083641b1e02b06800158df543e09d9259c69181e873
+ENV TEAMSPEAK_SHA256 b3891341a9ff4c4b6b0173ac57f1d64d4752550c95eeb26d2518ac2f5ca9fbc1
 ENV TS3_UID 1000
 
 RUN apt-get update -q \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:16.04
 
 # For the sake of safty, update and validate this hash for each new release!
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.5.1/teamspeak3-server_linux_amd64-3.5.1.tar.bz2
+ENV TEAMSPEAK_VERSION 3.5.1
+ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/$TEAMSPEAK_VERSION/teamspeak3-server_linux_amd64-$TEAMSPEAK_VERSION.tar.bz2
 ENV TEAMSPEAK_SHA256 aa991a7b88f4d6e24867a98548b808c093771b85443f986c8adb09e78e41eb79
 ENV TS3_UID 1000
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ I recommend to use the new 'docker volume' command in conjunction with this TS3-
 #### docker volume create (Since docker-engine 1.9 - RECOMMENDED) 
 ```
 docker volume create --name ts3-data
-docker run --name=ts3 -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v ts3-data:/home/ts3/data devalx/docker-teamspeak3:latest
+docker run --name=ts3 -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v ts3-data:/home/ts3/data akendo/docker-teamspeak3:latest
 ```
 
 #### data container
@@ -35,14 +35,14 @@ docker run --name=ts3 -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v ts3-data
 # create the data container
 docker run --name=ts3-data --entrypoint /bin/true devalx/docker-teamspeak3:latest
 # Now start the actual TS3-Server
-docker run --name=ts3 -d --volumes-from ts3-data -p 9987:9987/udp -p 30033:30033 -p 10011:10011 devalx/docker-teamspeak3:latest
+docker run --name=ts3 -d --volumes-from ts3-data -p 9987:9987/udp -p 30033:30033 -p 10011:10011 akendo/docker-teamspeak3:latest
 ```
 
 The data-container does not need to be running for this to work.
 
 #### Mounted Host-directory
 ```
-docker run --name ts3 -d -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v {FOLDER}:/home/ts3/data devalx/docker-teamspeak3:latest
+docker run --name ts3 -d -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v {FOLDER}:/home/ts3/data akendo/docker-teamspeak3:latest
 ```
 
 If you experience permission problems, especially after an upgrade, you can use the TS3_UID-env to set the user for the teamspeak-server process (inside the container). When using an mounted host-directory, the owner of the files will be the UID of this internal user (default is 1000)


### PR DESCRIPTION
Teamspeak 3 expects nowadays an UTF-8 encoding
Error at the start is:
```
WARNING |ServerLibPriv |   |The system locale is set to "C" this can cause unexpected 
behavior. We advice you to repair your locale!
```

The runtime error:
```
invalid utf8 string send to logging
```
Solution:
Add locales to the docker environment, as suggested in stackoverflow:
https://stackoverflow.com/a/28406007